### PR TITLE
Add support for handling the lic query param

### DIFF
--- a/django_atlassian_connect/decorators.py
+++ b/django_atlassian_connect/decorators.py
@@ -6,7 +6,7 @@ from functools import wraps
 
 def jwt_required(view_func):
     """
-    Make the function be validated through JWTAuthenticationMiddlewareand processed if the JWT is valid or raise a PermissionDenied if not.
+    Make the function be validated through JWTAuthenticationMiddleware and processed if the JWT is valid or raise a PermissionDenied if not.
     """
 
     def decorator(*args, **kwargs):
@@ -27,3 +27,18 @@ def jwt_qsh_exempt(view_func):
 
     decorator.jwt_qsh_exempt = True
     return wraps(view_func)(decorator)
+
+
+def enable_licensing(enable):
+    """
+    Mark a view function that the licensing is enabled on that request
+    """
+
+    def function_decorator(view_func):
+        def decorator(*args, **kwargs):
+            return view_func(*args, **kwargs)
+
+        decorator.enable_licensing = enable
+        return wraps(view_func)(decorator)
+
+    return function_decorator

--- a/django_atlassian_connect/tests/test_decorators.py
+++ b/django_atlassian_connect/tests/test_decorators.py
@@ -13,7 +13,7 @@ class JWTRequiredDecoratorTests(TestCase):
         def view(request):
             pass
 
-        decorated_view = jwt_required(normal_view)
+        decorated_view = jwt_required(view)
         self.assertTrue(decorated_view.jwt_required)
 
     def test_func_decorator(self):
@@ -21,7 +21,7 @@ class JWTRequiredDecoratorTests(TestCase):
         def view(request):
             pass
 
-        self.assertTrue(normal_view.jwt_required)
+        self.assertTrue(view.jwt_required)
 
 
 class JWTQshExemptTests(TestCase):
@@ -30,7 +30,7 @@ class JWTQshExemptTests(TestCase):
         def view(request):
             pass
 
-        self.assertTrue(normal_view.jwt_qsh_exempt)
+        self.assertTrue(view.jwt_qsh_exempt)
 
 
 class EnableLicensingTests(TestCase):
@@ -40,4 +40,4 @@ class EnableLicensingTests(TestCase):
         def view(request):
             pass
 
-        self.assertTrue(normal_view.enable_licensing)
+        self.assertTrue(view.enable_licensing)

--- a/django_atlassian_connect/tests/test_decorators.py
+++ b/django_atlassian_connect/tests/test_decorators.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from django_atlassian_connect.decorators import (
+    enable_licensing,
+    jwt_qsh_exempt,
+    jwt_required,
+)
+
+
+class JWTRequiredDecoratorTests(TestCase):
+    def test_func(self):
+        def view(request):
+            pass
+
+        decorated_view = jwt_required(normal_view)
+        self.assertTrue(decorated_view.jwt_required)
+
+    def test_func_decorator(self):
+        @jwt_required
+        def view(request):
+            pass
+
+        self.assertTrue(normal_view.jwt_required)
+
+
+class JWTQshExemptTests(TestCase):
+    def test_func_decorator(self):
+        @jwt_qsh_exempt
+        def view(request):
+            pass
+
+        self.assertTrue(normal_view.jwt_qsh_exempt)
+
+
+class EnableLicensingTests(TestCase):
+    @override_settings(ENABLE_LICENSING=True)
+    def test_func_decorator(self):
+        @enable_licensing(settings.ENABLE_LICENSING)
+        def view(request):
+            pass
+
+        self.assertTrue(normal_view.enable_licensing)


### PR DESCRIPTION
Given that a view is decoupled from the actual atlassian descriptor we need to know if a view will also check for the license or not on the query parameters.